### PR TITLE
changes for adding priority and delay in requests

### DIFF
--- a/stub/stub.go
+++ b/stub/stub.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"net/http"
 	"strings"
-	
+
 	"github.com/go-chi/chi"
 )
 
@@ -59,9 +59,15 @@ type Input struct {
 	Matches  map[string]interface{} `json:"matches"`
 }
 
+type Meta struct {
+	Priority               int `json:"priority"`               // minValue: 1, maxValue: INT_MAX, defaultValue: 5, 1 has highest priority
+	FixedDelayMilliseconds int `json:"fixedDelayMilliseconds"` // min: 0
+}
+
 type Output struct {
 	Data  map[string]interface{} `json:"data"`
 	Error string                 `json:"error"`
+	Meta  Meta                   `json:"meta"`
 }
 
 func addStub(w http.ResponseWriter, r *http.Request) {
@@ -106,7 +112,7 @@ func validateStub(stub *Stub) error {
 	if stub.Method == "" {
 		return fmt.Errorf("Method name can't be emtpy")
 	}
-	
+
 	// due to golang implementation
 	// method name must capital
 	stub.Method = strings.Title(stub.Method)
@@ -131,9 +137,10 @@ func validateStub(stub *Stub) error {
 }
 
 type findStubPayload struct {
-	Service string                 `json:"service"`
-	Method  string                 `json:"method"`
-	Data    map[string]interface{} `json:"data"`
+	Service         string                 `json:"service"`
+	Method          string                 `json:"method"`
+	Data            map[string]interface{} `json:"data"`
+	FromAdminServer bool
 }
 
 func handleFindStub(w http.ResponseWriter, r *http.Request) {
@@ -143,11 +150,11 @@ func handleFindStub(w http.ResponseWriter, r *http.Request) {
 		responseError(err, w)
 		return
 	}
-	
+
 	// due to golang implementation
 	// method name must capital
 	stub.Method = strings.Title(stub.Method)
-	
+	stub.FromAdminServer = true
 	output, err := findStub(stub)
 	if err != nil {
 		log.Println(err)

--- a/stub/stub_test.go
+++ b/stub/stub_test.go
@@ -48,7 +48,7 @@ func TestStub(t *testing.T) {
 				return httptest.NewRequest("GET", "/", nil)
 			},
 			handler: listStub,
-			expect:  "{\"Testing\":{\"TestMethod\":[{\"Input\":{\"equals\":{\"Hola\":\"Mundo\"},\"contains\":null,\"matches\":null},\"Output\":{\"data\":{\"Hello\":\"World\"},\"error\":\"\"}}]}}\n",
+			expect:  "{\"Testing\":{\"TestMethod\":[{\"Input\":{\"equals\":{\"Hola\":\"Mundo\"},\"contains\":null,\"matches\":null},\"Output\":{\"data\":{\"Hello\":\"World\"},\"error\":\"\",\"meta\":{\"priority\":5,\"fixedDelayMilliseconds\":0}}}]}}\n",
 		},
 		{
 			name: "find stub equals",
@@ -57,7 +57,7 @@ func TestStub(t *testing.T) {
 				return httptest.NewRequest("POST", "/find", bytes.NewReader([]byte(payload)))
 			},
 			handler: handleFindStub,
-			expect:  "{\"data\":{\"Hello\":\"World\"},\"error\":\"\"}\n",
+			expect:  "{\"data\":{\"Hello\":\"World\"},\"error\":\"\",\"meta\":{\"priority\":5,\"fixedDelayMilliseconds\":0}}\n",
 		},
 		{
 			name: "add nested stub equals",
@@ -97,7 +97,7 @@ func TestStub(t *testing.T) {
 				return httptest.NewRequest("POST", "/find", bytes.NewReader([]byte(payload)))
 			},
 			handler: handleFindStub,
-			expect:  "{\"data\":{\"Hello\":\"World\"},\"error\":\"\"}\n",
+			expect:  "{\"data\":{\"Hello\":\"World\"},\"error\":\"\",\"meta\":{\"priority\":5,\"fixedDelayMilliseconds\":0}}\n",
 		},
 		{
 			name: "add stub contains",
@@ -137,7 +137,7 @@ func TestStub(t *testing.T) {
 				return httptest.NewRequest("GET", "/find", bytes.NewReader([]byte(payload)))
 			},
 			handler: handleFindStub,
-			expect:  "{\"data\":{\"hello\":\"world\"},\"error\":\"\"}\n",
+			expect:  "{\"data\":{\"hello\":\"world\"},\"error\":\"\",\"meta\":{\"priority\":5,\"fixedDelayMilliseconds\":0}}\n",
 		},
 		{
 			name: "add nested stub contains",
@@ -186,7 +186,7 @@ func TestStub(t *testing.T) {
 				return httptest.NewRequest("GET", "/find", bytes.NewReader([]byte(payload)))
 			},
 			handler: handleFindStub,
-			expect:  "{\"data\":{\"hello\":\"world\"},\"error\":\"\"}\n",
+			expect:  "{\"data\":{\"hello\":\"world\"},\"error\":\"\",\"meta\":{\"priority\":5,\"fixedDelayMilliseconds\":0}}\n",
 		},
 		{
 			name: "add stub matches regex",
@@ -223,7 +223,7 @@ func TestStub(t *testing.T) {
 				return httptest.NewRequest("GET", "/find", bytes.NewReader([]byte(payload)))
 			},
 			handler: handleFindStub,
-			expect:  "{\"data\":{\"reply\":\"OK\"},\"error\":\"\"}\n",
+			expect:  "{\"data\":{\"reply\":\"OK\"},\"error\":\"\",\"meta\":{\"priority\":5,\"fixedDelayMilliseconds\":0}}\n",
 		},
 		{
 			name: "add nested stub matches regex",
@@ -275,7 +275,7 @@ func TestStub(t *testing.T) {
 				return httptest.NewRequest("GET", "/find", bytes.NewReader([]byte(payload)))
 			},
 			handler: handleFindStub,
-			expect:  "{\"data\":{\"reply\":\"OK\"},\"error\":\"\"}\n",
+			expect:  "{\"data\":{\"reply\":\"OK\"},\"error\":\"\",\"meta\":{\"priority\":5,\"fixedDelayMilliseconds\":0}}\n",
 		},
 		{
 			name: "error find stub contains",
@@ -300,6 +300,49 @@ func TestStub(t *testing.T) {
 			},
 			handler: handleFindStub,
 			expect:  "Can't find stub \n\nService: Testing \n\nMethod: TestMethod \n\nInput\n\n{\n\tHola: Dunia\n}\n\nClosest Match \n\nequals:{\n\tHola: Mundo\n}",
+		},
+		{
+			name: "add stub with fixedDelay and priority",
+			mock: func() *http.Request {
+				payload := `{
+						"service": "Testing",
+						"method":"TestMethod",
+						"input":{
+							"equals":{
+								"Hola":"Meta"
+							}
+						},
+						"output":{
+							"data":{
+								"Hello":"Meta"
+							},
+							"meta": {
+								"priority": 1,
+								"fixedDelayMilliseconds": 99
+							}
+						}
+					}`
+				requestBody := bytes.NewReader([]byte(payload))
+				return httptest.NewRequest("POST", "/add", requestBody)
+			},
+			handler: addStub,
+			expect:  `Success add stub`,
+		},
+		{
+			name: "find nested stub matches regex",
+			mock: func() *http.Request {
+				payload := `{
+						"service":"Testing",
+						"method":"TestMethod",
+						"data":{
+								"Hola":"Meta"
+							}
+						}
+					}`
+				return httptest.NewRequest("GET", "/find", bytes.NewReader([]byte(payload)))
+			},
+			handler: handleFindStub,
+			expect:  "{\"data\":{\"Hello\":\"Meta\"},\"error\":\"\",\"meta\":{\"priority\":1,\"fixedDelayMilliseconds\":99}}\n",
 		},
 	}
 


### PR DESCRIPTION
Added Meta attributes to output as suggested by authors -> https://github.com/tokopedia/gripmock/pull/71#discussion_r793384525

FixedDelayMilliseconds , Priority: same properties and behaviour as wiremock
